### PR TITLE
Motion gating and saving results

### DIFF
--- a/strong_sort/sort/detection.py
+++ b/strong_sort/sort/detection.py
@@ -27,7 +27,7 @@ class Detection(object):
     """
 
     def __init__(self, class_id, tlwh, confidence, feature):
-        self.tlwh = np.asarray(tlwh, dtype=np.float)
+        self.tlwh = np.asarray(tlwh, dtype=np.float32)
         self.confidence = float(confidence)
         self.class_id = int(class_id)
         self.feature = np.asarray(feature.cpu(), dtype=np.float32)

--- a/strong_sort/sort/nn_matching.py
+++ b/strong_sort/sort/nn_matching.py
@@ -101,9 +101,6 @@ class NearestNeighborDistanceMetric(object):
     ----------
     metric : str
         Either "euclidean" or "cosine".
-    matching_threshold: float
-        The matching threshold. Samples with larger distance are considered an
-        invalid match.
     budget : Optional[int]
         If not None, fix samples per class to at most this number. Removes
         the oldest samples when the budget is reached.
@@ -114,7 +111,7 @@ class NearestNeighborDistanceMetric(object):
         that have been observed so far.
     """
 
-    def __init__(self, metric, matching_threshold, budget=None):
+    def __init__(self, metric, budget=None):
         if metric == "euclidean":
             self._metric = _nn_euclidean_distance
         elif metric == "cosine":
@@ -122,7 +119,6 @@ class NearestNeighborDistanceMetric(object):
         else:
             raise ValueError(
                 "Invalid metric; must be either 'euclidean' or 'cosine'")
-        self.matching_threshold = matching_threshold
         self.budget = budget
         self.samples = {}
 

--- a/strong_sort/sort/track.py
+++ b/strong_sort/sort/track.py
@@ -96,6 +96,7 @@ class Track:
 
         self.kf = KalmanFilter()
         self.mean, self.covariance = self.kf.initiate(detection)
+        self.last_association = detection
 
     def to_tlwh(self):
         """Get current position in bounding box format `(top left x, top left y,
@@ -126,6 +127,16 @@ class Track:
         ret[2:] = ret[:2] + ret[2:]
         return ret
 
+    def last_associated_bbox(self):
+        """Get the `(centroid x, centroid y, aspec ratio, height)` bounding box
+        from the last measurement associated to the track.
+        
+        Returns
+        -------
+        ndarray
+            The bounding box from the last detection associated to the track.
+        """
+        return self.last_association.copy()
 
     def ECC(self, src, dst, warp_mode = cv2.MOTION_EUCLIDEAN, eps = 1e-5,
         max_iter = 100, scale = 0.1, align = False):
@@ -255,7 +266,7 @@ class Track:
         self.age += 1
         self.time_since_update += 1
 
-    def predict(self, kf):
+    def predict(self):
         """Propagate the state distribution to the current time step using a
         Kalman filter prediction step.
 
@@ -279,6 +290,7 @@ class Track:
         """
         self.conf = conf
         self.class_id = class_id.int()
+        self.last_association = detection.to_xyah()
         self.mean, self.covariance = self.kf.update(self.mean, self.covariance, detection.to_xyah(), detection.confidence)
 
         feature = detection.feature / np.linalg.norm(detection.feature)

--- a/strong_sort/sort/track.py
+++ b/strong_sort/sort/track.py
@@ -74,8 +74,7 @@ class Track:
             conf, 
             n_init, 
             max_age, 
-            ema_alpha, 
-            feature = None
+            ema_alpha
         ):
         self.track_id = track_id
         self.class_id = int(class_id)
@@ -85,17 +84,14 @@ class Track:
         self.ema_alpha = ema_alpha
 
         self.state = TrackState.Tentative
-        self.features = []
-        if feature is not None:
-            feature /= np.linalg.norm(feature)
-            self.features.append(feature)
+        self.features = [detection.feature / np.linalg.norm(detection.feature)]
 
         self.conf = conf
         self._n_init = n_init
         self._max_age = max_age
 
         self.kf = KalmanFilter()
-        self.mean, self.covariance = self.kf.initiate(detection)
+        self.mean, self.covariance = self.kf.initiate(detection.to_xyah())
         self.last_association = detection
 
     def to_tlwh(self):
@@ -136,7 +132,7 @@ class Track:
         ndarray
             The bounding box from the last detection associated to the track.
         """
-        return self.last_association.copy()
+        return self.last_association.to_xyah()
 
     def ECC(self, src, dst, warp_mode = cv2.MOTION_EUCLIDEAN, eps = 1e-5,
         max_iter = 100, scale = 0.1, align = False):
@@ -290,7 +286,7 @@ class Track:
         """
         self.conf = conf
         self.class_id = class_id.int()
-        self.last_association = detection.to_xyah()
+        self.last_association = detection
         self.mean, self.covariance = self.kf.update(self.mean, self.covariance, detection.to_xyah(), detection.confidence)
 
         feature = detection.feature / np.linalg.norm(detection.feature)

--- a/strong_sort/sort/tracker.py
+++ b/strong_sort/sort/tracker.py
@@ -33,29 +33,49 @@ class Tracker:
     tracks : List[Track]
         The list of active tracks at the current time step.
     """
-    GATING_THRESHOLD = kalman_filter.chi2inv95[4]
 
     def __init__(
             self, 
-            metric, 
+            appearance_metric, 
+            max_appearance_distance = 0.2,
             max_iou_distance = 0.9, 
             max_age = 30, 
             n_init = 3, 
             ema_alpha = 0.9, 
-            mc_lambda = 0.995,
-            matching_cascade = False
+            mc_lambda = 0.995, 
+            matching_cascade = False, 
+            only_position = False, 
+            motion_gate_coefficient = 1.0,
+            max_centroid_distance = None
         ):
-        self.metric = metric
+        self.appearance_metric = appearance_metric
+        self.max_appearance_distance = max_appearance_distance
+        self.max_motion_distance = kalman_filter.chi2inv95[2 if only_position else 4] * motion_gate_coefficient
         self.max_iou_distance = max_iou_distance
+        self.max_centroid_distance = max_centroid_distance
         self.max_age = max_age
         self.n_init = n_init
         self.ema_alpha = ema_alpha
         self.mc_lambda = mc_lambda
         self.matching_cascade = matching_cascade
+        self.only_position = only_position
 
-        self.kf = kalman_filter.KalmanFilter()
         self.tracks = []
         self._next_id = 1
+
+    def centroid_gate(self, tracks, detections, track_indices, detection_indices):
+        tks_centroids = np.array(
+            [tracks[i].last_associated_bbox()[:2] for i in track_indices], dtype=np.int32)
+        dts_centroids = np.array(
+            [detections[i].to_xyah()[:2] for i in detection_indices], dtype=np.int32)
+        return np.array(
+            [np.linalg.norm(dts_centroids - c, axis=1) > self.max_centroid_distance for c in tks_centroids])
+
+    def gated_iou_metric(self, *args, **kwargs):
+        cost_matrix = iou_matching.iou_cost(*args, **kwargs)
+        gate = cost_matrix > self.max_iou_distance
+        cost_matrix[gate] = cost_matrix[gate] + linear_assignment.INFTY_COST
+        return cost_matrix
 
     def predict(self):
         """Propagate track state distributions one time step forward.
@@ -63,7 +83,7 @@ class Tracker:
         This function should be called once every time step, before `update`.
         """
         for track in self.tracks:
-            track.predict(self.kf)
+            track.predict()
 
     def increment_ages(self):
         for track in self.tracks:
@@ -105,60 +125,42 @@ class Tracker:
                 continue
             features += track.features
             targets += [track.track_id for _ in track.features]
-        self.metric.partial_fit(np.asarray(features), np.asarray(targets), active_targets)
+        self.appearance_metric.partial_fit(np.asarray(features), np.asarray(targets), active_targets)
 
-    # def _full_cost_metric(self, tracks, dets, track_indices, detection_indices):
-    #     """
-    #     This implements the full lambda-based cost-metric. However, in doing so, it disregards
-    #     the possibility to gate the position only which is provided by
-    #     linear_assignment.gate_cost_matrix(). Instead, I gate by everything.
-    #     Note that the Mahalanobis distance is itself an unnormalised metric. Given the cosine
-    #     distance being normalised, we employ a quick and dirty normalisation based on the
-    #     threshold: that is, we divide the positional-cost by the gating threshold, thus ensuring
-    #     that the valid values range 0-1.
-    #     Note also that the authors work with the squared distance. I also sqrt this, so that it
-    #     is more intuitive in terms of values.
-    #     """
-    #     # Compute First the Position-based Cost Matrix
-    #     pos_cost = np.empty([len(track_indices), len(detection_indices)])
-    #     msrs = np.asarray([dets[i].to_xyah() for i in detection_indices])
-    #     for row, track_idx in enumerate(track_indices):
-    #         pos_cost[row, :] = np.sqrt(
-    #             self.kf.gating_distance(
-    #                 tracks[track_idx].mean, tracks[track_idx].covariance, msrs, False
-    #             )
-    #         ) / self.GATING_THRESHOLD
-    #     pos_gate = pos_cost > 1.0
-    #     # Now Compute the Appearance-based Cost Matrix
-    #     app_cost = self.metric.distance(
-    #         np.array([dets[i].feature for i in detection_indices]),
-    #         np.array([tracks[i].track_id for i in track_indices]),
-    #     )
-    #     app_gate = app_cost > self.metric.matching_threshold
-    #     # Now combine and threshold
-    #     cost_matrix = self._lambda * pos_cost + (1 - self._lambda) * app_cost
-    #     cost_matrix[np.logical_or(pos_gate, app_gate)] = linear_assignment.INFTY_COST
-    #     # Return Matrix
-    #     return cost_matrix
+    def gated_metric(self, tracks, detections, track_indices, detection_indices):
+        features = np.array([detections[i].feature for i in detection_indices])
+        measurements = np.asarray([detections[i].to_xyah() for i in detection_indices])
+        targets = np.array([tracks[i].track_id for i in track_indices])
+        # Appearance cost
+        appearance_cost_matrix = self.appearance_metric.distance(features, targets) # Num_targets x Num_features
+        # Motion cost
+        motion_cost_matrix = np.zeros_like(appearance_cost_matrix)
+        for row, track_idx in enumerate(track_indices):
+            track = tracks[track_idx]
+            motion_cost_matrix[row] = track.kf.gating_distance(
+                track.mean, track.covariance, measurements, self.only_position)
+        # Gate
+        gate = np.logical_or(
+            appearance_cost_matrix > self.max_appearance_distance,
+            motion_cost_matrix > self.max_motion_distance)
+        if self.max_centroid_distance is not None:
+            gate[:] = np.logical_or(
+                gate, self.centroid_gate(tracks, detections, track_indices, detection_indices))
+        # Final cost matrix
+        lmb = self.mc_lambda
+        appearance_cost_matrix[:] = lmb * appearance_cost_matrix + (1 - lmb) * motion_cost_matrix
+        appearance_cost_matrix[gate] = appearance_cost_matrix[gate] + linear_assignment.INFTY_COST
+        return appearance_cost_matrix
 
-    def _match(self, detections):
-
-        def gated_metric(tracks, detections, track_indices, detection_indices):
-            features = np.array([detections[i].feature for i in detection_indices])
-            targets = np.array([tracks[i].track_id for i in track_indices])
-            cost_matrix = self.metric.distance(features, targets) # cost matrix (Num_targets, Num_features)
-            cost_matrix = linear_assignment.gate_cost_matrix(
-                cost_matrix, tracks, detections, track_indices, detection_indices, self.mc_lambda)
-            return cost_matrix
-        
+    def _match(self, detections):        
         # Split track set into confirmed and unconfirmed tracks.
         confirmed_tracks = [i for i, t in enumerate(self.tracks) if t.is_confirmed()]
         unconfirmed_tracks = [i for i, t in enumerate(self.tracks) if not t.is_confirmed()]
 
         # Associate confirmed tracks using appearance and motion cost.
         matches_a, unmatched_tracks_a, unmatched_detections = linear_assignment.matching_cascade(
-            gated_metric, self.metric.matching_threshold, self.max_age, 
-            self.tracks, detections, confirmed_tracks, matching_cascade=self.matching_cascade)
+            self.gated_metric, self.max_age, self.tracks, detections, 
+            confirmed_tracks, matching_cascade=self.matching_cascade)
 
         # Associate remaining tracks together with unconfirmed tracks using IOU.
         iou_track_candidates = unconfirmed_tracks + [
@@ -169,8 +171,8 @@ class Tracker:
             self.tracks[k].time_since_update != 1]
         matches_b, unmatched_tracks_b, unmatched_detections = \
             linear_assignment.min_cost_matching(
-                iou_matching.iou_cost, self.max_iou_distance, self.tracks,
-                detections, iou_track_candidates, unmatched_detections)
+                self.gated_iou_metric, self.tracks, detections, 
+                iou_track_candidates, unmatched_detections)
 
         matches = matches_a + matches_b
         unmatched_tracks = list(set(unmatched_tracks_a + unmatched_tracks_b))

--- a/strong_sort/sort/tracker.py
+++ b/strong_sort/sort/tracker.py
@@ -181,8 +181,8 @@ class Tracker:
     def _initiate_track(self, detection, class_id, conf):
         self.tracks.append(
             Track(
-                detection.to_xyah(), self._next_id, class_id, conf, 
-                self.n_init, self.max_age, self.ema_alpha, detection.feature
+                detection, self._next_id, class_id, conf, 
+                self.n_init, self.max_age, self.ema_alpha
             )
         )
         self._next_id += 1

--- a/strong_sort/strong_sort.py
+++ b/strong_sort/strong_sort.py
@@ -60,19 +60,13 @@ class StrongSORT(object):
             ema_alpha, mc_lambda, matching_cascade, only_position, motion_gate_coefficient, 
             max_centroid_distance)
 
-    def update(self, bbox_xywh, confidences, classes, ori_img):
-        self.height, self.width = ori_img.shape[:2]
-        # generate detections
-        features = self._get_features(bbox_xywh, ori_img)
-        bbox_tlwh = self._xywh_to_tlwh(bbox_xywh)
+    def update(self, bboxes_xyxy, confidences, classes, im0):
+        features = self.get_features(bboxes_xyxy, im0)
+        bboxes_tlwh = self.xyxy2tlwh(bboxes_xyxy)
         detections = [
-            Detection(classes[i], bbox_tlwh[i], conf, features[i]) \
+            Detection(classes[i], bboxes_tlwh[i], conf, features[i]) \
             for i, conf in enumerate(confidences)
         ]
-
-        # run on non-maximum supression
-        # boxes = np.array([d.tlwh for d in detections]) ### ????
-        # scores = np.array([d.confidence for d in detections]) ### ????
 
         # update tracker
         self.tracker.predict()
@@ -81,77 +75,26 @@ class StrongSORT(object):
         # output bbox identities
         outputs = []
         for track in self.tracker.tracks:
-            if not track.is_confirmed() or track.time_since_update > 1:
+            if not track.is_confirmed() or track.time_since_update:
                 continue
-
-            box = track.to_tlwh()
-            x1, y1, x2, y2 = self._tlwh_to_xyxy(box)
-            
-            track_id = track.track_id
-            class_id = track.class_id
-            conf = track.conf
-            outputs.append(np.array([x1, y1, x2, y2, track_id, class_id, conf], dtype='object'))
-        try:
-            return np.stack(outputs, axis=0)
-        except ValueError:
-            return np.zeros((0, 7), dtype='object')
-
-    """
-    TODO:
-        Convert bbox from xc_yc_w_h to xtl_ytl_w_h
-    Thanks JieChen91@github.com for reporting this bug!
-    """
-    @staticmethod
-    def _xywh_to_tlwh(bbox_xywh):
-        if isinstance(bbox_xywh, np.ndarray):
-            bbox_tlwh = bbox_xywh.copy()
-        elif isinstance(bbox_xywh, torch.Tensor):
-            bbox_tlwh = bbox_xywh.clone()
-        bbox_tlwh[:, 0] = bbox_xywh[:, 0] - bbox_xywh[:, 2] / 2.
-        bbox_tlwh[:, 1] = bbox_xywh[:, 1] - bbox_xywh[:, 3] / 2.
-        return bbox_tlwh
-
-    def _xywh_to_xyxy(self, bbox_xywh):
-        x, y, w, h = bbox_xywh
-        x1 = max(int(x - w / 2), 0)
-        x2 = min(int(x + w / 2), self.width - 1)
-        y1 = max(int(y - h / 2), 0)
-        y2 = min(int(y + h / 2), self.height - 1)
-        return x1, y1, x2, y2
-
-    def _tlwh_to_xyxy(self, bbox_tlwh):
-        """
-        TODO:
-            Convert bbox from xtl_ytl_w_h to xc_yc_w_h
-        Thanks JieChen91@github.com for reporting this bug!
-        """
-        x, y, w, h = bbox_tlwh
-        x1 = max(int(x), 0)
-        x2 = min(int(x+w), self.width - 1)
-        y1 = max(int(y), 0)
-        y2 = min(int(y+h), self.height - 1)
-        return x1, y1, x2, y2
+            det = track.last_association
+            outputs.append([*det.tlwh, track.track_id, det.class_id, det.confidence])
+        return np.asarray(outputs)
 
     def increment_ages(self):
         self.tracker.increment_ages()
 
-    def _xyxy_to_tlwh(self, bbox_xyxy):
-        x1, y1, x2, y2 = bbox_xyxy
+    def xyxy2tlwh(self, bboxes_xyxy):
+        # Convert nx4 boxes from [x1, y1, x2, y2] to [x1, y1, w, h] where xy1=top-left, xy2=bottom-right
+        y = bboxes_xyxy.clone() if isinstance(bboxes_xyxy, torch.Tensor) else np.copy(bboxes_xyxy)
+        y[:, 2] = bboxes_xyxy[:, 2] - bboxes_xyxy[:, 0]  # width
+        y[:, 3] = bboxes_xyxy[:, 3] - bboxes_xyxy[:, 1]  # height
+        return y
 
-        t = x1
-        l = y1
-        w = int(x2 - x1)
-        h = int(y2 - y1)
-        return t, l, w, h
-
-    def _get_features(self, bbox_xywh, ori_img):
-        im_crops = []
-        for box in bbox_xywh:
-            x1, y1, x2, y2 = self._xywh_to_xyxy(box)
-            im = ori_img[y1:y2, x1:x2]
-            im_crops.append(im)
-        if im_crops:
-            features = self.extractor(im_crops)
-        else:
-            features = np.array([])
-        return features
+    def get_features(self, bboxes_xyxy, image):
+        crops = []
+        for box in bboxes_xyxy:
+            x1, y1, x2, y2 = box
+            im = image[y1:y2, x1:x2]
+            crops.append(im)
+        return self.extractor(crops)

--- a/strong_sort/strong_sort.py
+++ b/strong_sort/strong_sort.py
@@ -24,14 +24,17 @@ class StrongSORT(object):
     def __init__(
             self, 
             device, 
-            max_dist = 0.2, 
+            max_appearance_distance = 0.2, 
             nn_budget = 100, 
             max_iou_distance = 0.7, 
             max_age = 70, 
             n_init = 3, 
             ema_alpha = 0.9, 
             mc_lambda = 0.995, 
-            matching_cascade = False
+            matching_cascade = False,
+            only_position = False,            
+            motion_gate_coefficient = 1.0, 
+            max_centroid_distance = None
         ):
         if not osp.isfile(EXTRACTOR_PATH):
             print(f'Feature extractor not found in {EXTRACTOR_PATH}')
@@ -51,10 +54,11 @@ class StrongSORT(object):
             verbose=False
         )
 
-        self.max_dist = max_dist
-        metric = NearestNeighborDistanceMetric("cosine", self.max_dist, nn_budget)
+        appearance_metric = NearestNeighborDistanceMetric("cosine", nn_budget)
         self.tracker = Tracker(
-            metric, max_iou_distance, max_age, n_init, ema_alpha, mc_lambda, matching_cascade)
+            appearance_metric, max_appearance_distance, max_iou_distance, max_age, n_init, 
+            ema_alpha, mc_lambda, matching_cascade, only_position, motion_gate_coefficient, 
+            max_centroid_distance)
 
     def update(self, bbox_xywh, confidences, classes, ori_img):
         self.height, self.width = ori_img.shape[:2]

--- a/track_v7.py
+++ b/track_v7.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import argparse
-import os
 
 # limit the number of cpus used by high performance libraries
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -37,10 +36,12 @@ if str(ROOT / 'strong_sort') not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from yolov7.models.experimental import attempt_load
-from yolov7.utils.datasets import LoadStreams, LoadImages
+from yolov7.utils.plots import get_rgb_colors
+from yolov7.utils.datasets import LoadImages
 from yolov7.utils.general import (check_img_size, check_requirements, check_imshow, 
                                   non_max_suppression, apply_classifier, scale_coords, 
-                                  xyxy2xywh, strip_optimizer, set_logging, increment_path)
+                                  xyxy2xywh, strip_optimizer, set_logging, increment_path,
+                                  save_argparser_arguments)
 from yolov7.utils.plots import plot_one_box
 from yolov7.utils.torch_utils import select_device, load_classifier, time_synchronized, TracedModel
 
@@ -51,45 +52,32 @@ from strong_sort.strong_sort import StrongSORT
 
 def _build_strong_sort(opt):
     return StrongSORT(
-        select_device(opt.device), 
-        max_dist=opt.final_gate, 
+        device=select_device(opt.device), 
+        max_appearance_distance=opt.appearance_gate, 
         nn_budget=opt.feature_bank_size, 
         max_iou_distance=opt.iou_gate, 
         max_age=opt.max_age, 
         n_init=opt.init_period, 
         ema_alpha=opt.feature_momentum, 
         mc_lambda=opt.appearance_lambda, 
-        matching_cascade=opt.matching_cascade
+        matching_cascade=opt.matching_cascade,
+        only_position=opt.motion_only_position,
+        motion_gate_coefficient=opt.motion_gate_coefficient,
+        max_centroid_distance=opt.max_centroid_distance
     )
 
-def increment_file_path(path):
-    version = 1
-    while os.path.isfile(path):
-        version += 1
-        path = version.join(os.path.splitext(path))
-    return path
-
-def _save_opt(opt, save_dir, exist_ok):
-    args = vars(opt)
-    padding = max(len(k) for k in args.keys())
-    lines = [f'{k: <{padding}} : {v}\n' for k, v in args.items()]
-    dest_path = os.path.abspath(os.path.join(save_dir, 'arguments.txt'))
-    dest_path = dest_path if exist_ok else increment_file_path(dest_path)
-    with open(dest_path, mode='w') as opt_file:
-        opt_file.writelines(lines)
 
 def detect(opt):
     assert os.path.isdir(opt.source) or os.path.isfile(opt.source), 'Source must be a video file or a directory'
     # strong_sort_weights = opt.strong_sort_weights  # re-id model.pt path
-    # view_img = check_imshow()  ### Find a fix to also run in Colab
+    # view_img = check_imshow()  # Cannot run in Colab
 
     # Directories
     save_dir = Path(
-        increment_path(Path(opt.project).absolute() / opt.name, exist_ok=opt.exist_ok)
-    )  # increment run
+        increment_path(Path(opt.project).absolute() / opt.name, exist_ok=opt.exist_ok))  # increment path
     (save_dir / 'labels' if opt.save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make labels dir
 
-    _save_opt(opt, save_dir, opt.exist_ok)
+    save_argparser_arguments(opt, str(save_dir / 'arguments.txt'), opt.exist_ok)
 
     # Initialize
     set_logging()
@@ -121,11 +109,9 @@ def detect(opt):
 
     # cfg = get_config(config_file=opt.config_strongsort)
 
-    trajectory = {}
-
     # Get names and colors
     names = model.module.names if hasattr(model, 'module') else model.names
-    colors = [[np.random.randint(0, 255) for _ in range(3)] for _ in names]
+    colors = get_rgb_colors(len(names), cmin=50, cmax=200, gray_colors=False)
 
     # Run inference
     if device.type != 'cpu':
@@ -146,6 +132,7 @@ def detect(opt):
             if dataset.mode == 'video':
                 if not opt.video_sequence or strong_sort is None:
                     strong_sort = _build_strong_sort(opt)
+                    trajectorys = {}
                 if opt.save_img:
                     (save_dir / 'images' / path_base_name).mkdir(parents=True, exist_ok=True)
                 if opt.save_txt:
@@ -164,6 +151,7 @@ def detect(opt):
             else:
                 if strong_sort is None:
                     strong_sort = _build_strong_sort(opt)
+                    trajectorys = {}
                 if opt.save_vid and vid_writer is None:
                     vid_writer = cv2.VideoWriter(str(save_dir / 'video_from_imgs.mp4'), 
                                                  cv2.VideoWriter_fourcc(*'mp4v'), 
@@ -230,10 +218,11 @@ def detect(opt):
                     if opt.draw_trajectory:
                         # object trajectory
                         center = int(bbox[[0, 2]].sum() / 2 + 0.5), int(bbox[[1, 3]].sum() / 2 + 0.5)
-                        trajectory.setdefault(track_id, []).append(center)
-                        for c in range(-1, -21, -1): # Draw only the last 20 points
+                        track_trajs = trajectorys.setdefault(track_id, [])
+                        track_trajs.append(center)
+                        for c in range(-1, -21, -1):  # Draw only the last 20 points
                             try:
-                                c1, c0 = trajectory[track_id][c], trajectory[track_id][c-1]
+                                c1, c0 = track_trajs[c], track_trajs[c-1]
                             except IndexError:
                                 break
                             cv2.line(im0, c0, c1, colors[cls], 3)
@@ -302,7 +291,7 @@ def detect(opt):
         # if show_vid:
         #     inf = (f'{result_message}Done. ({t2 - t1:.3f}s)')
         #     # cv2.putText(im0, str(inf), (30, 160), cv2.FONT_HERSHEY_SIMPLEX, 0.7, (40, 40, 40), 2)
-        #     cv2.imshow(str(p), im0) ### Find a fix to also run in Colab
+        #     cv2.imshow(str(p), im0)  # Find a fix to also run in Colab
         #     if cv2.waitKey(1) == ord('q'):  # q to quit
         #         break
 
@@ -317,6 +306,7 @@ def detect(opt):
                 print('Error while saving image/frame:')
                 print('    - ID   :', frame_id)
                 print('    - File :', path)
+        
         if opt.save_vid:
             vid_writer.write(im0)
 
@@ -392,13 +382,13 @@ if __name__ == '__main__':
     parser.add_argument(
         '--source', 
         type=str, default='.', 
-        help='source data (video files or directory with images or/and videos) for tracking'
+        help='source data (video file or directory with images or/and videos) for tracking'
     )
 
     parser.add_argument(
         '--video-sequence', 
         action='store_true', 
-        help='keep tracker alive (don\'t reinstantiate) between videos'
+        help='keep tracker alive (do not reinstantiate) between videos'
     )
 
     parser.add_argument(
@@ -418,31 +408,31 @@ if __name__ == '__main__':
     parser.add_argument(
         '--project', 
         default='runs/track', 
-        help='save results to ./project/name'
+        help='save results to /project/name'
     )
 
     parser.add_argument(
         '--name', 
         default='exp', 
-        help='save results to ./project/name'
+        help='save results to /project/name'
     )
 
     parser.add_argument(
         '--exist-ok', 
         action='store_true', 
-        help='existing ./project/name ok, do not increment'
+        help='existing /project/name ok, do not increment dir path'
     )
 
     parser.add_argument(
         '--save-txt', 
         action='store_true', 
-        help='save tracking results to ./project/name/labels/*.txt'
+        help='save tracking results to /project/name/labels/*.txt'
     )
 
     parser.add_argument(
         '--save-img', 
         action='store_true', 
-        help='save processed images/frames to ./project/name/images/*/*.jpg'
+        help='save processed images/frames to /project/name/images/*/*.jpg'
     )
 
     parser.add_argument(
@@ -472,8 +462,8 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--line-thickness', 
-        default=2, type=int, 
-        help='bounding box thickness (pixels)'
+        type=int, default=2, 
+        help='bounding box thickness in pixels'
     )
 
     parser.add_argument(
@@ -485,13 +475,13 @@ if __name__ == '__main__':
     parser.add_argument(
         '--hide-conf', 
         action='store_true', 
-        help='hide detection confidences in bounding boxes label'
+        help='hide detection confidence in bounding box label'
     )
 
     parser.add_argument(
         '--hide-class', 
         action='store_true', 
-        help='hide class id in bounding boxes label'
+        help='hide class id in bounding box label'
     )
 
     parser.add_argument(
@@ -520,42 +510,42 @@ if __name__ == '__main__':
     parser.add_argument(
         '--matching-cascade',
         action='store_true',
-        help='apply DeepSORT matching cascade per tracker age'
+        help='apply DeepSORT matching cascade'
     )
     
     parser.add_argument(
-        '--appearance-lambda', # Old strong_sort.yaml STRONGSORT.MC_LAMBDA
+        '--appearance-lambda',  # Old strong_sort.yaml STRONGSORT.MC_LAMBDA
         type=float, default=0.995,
         help='appearance cost weight for appearance-motion cost matrix calculation'
     )
     
     parser.add_argument(
-        '--iou-gate', # Old strong_sort.yaml STRONGSORT.MAX_IOU_DISTANCE
+        '--iou-gate',  # Old strong_sort.yaml STRONGSORT.MAX_IOU_DISTANCE
         type=float, default=0.7,
         help='IoU distance gate for the final IoU matching'
     )
 
     parser.add_argument(
-        '--ecc', # Old strong_sort.yaml STRONGSORT.ECC
+        '--ecc',  # Old strong_sort.yaml STRONGSORT.ECC
         action='store_true',
         help='apply camera motion compensation using ECC'
     )
     
     ### TODO: choose between feature update or feature bank
     parser.add_argument(
-        '--feature-bank-size', # Old strong_sort.yaml STRONGSORT.NN_BUDGET
+        '--feature-bank-size',  # Old strong_sort.yaml STRONGSORT.NN_BUDGET
         type=int, default=100,
         help='num of features to store per Track for appearance distance calculation'
     )
 
     parser.add_argument(
-        '--init-period', # Old strong_sort.yaml STRONGSORT.N_INIT
+        '--init-period',  # Old strong_sort.yaml STRONGSORT.N_INIT
         type=int, default=3,
         help='size of Track initialization period in frames'
     )
     
     parser.add_argument(
-        '--max-age', # Old strong_sort.yaml STRONGSORT.MAX_AGE
+        '--max-age',  # Old strong_sort.yaml STRONGSORT.MAX_AGE
         type=int, default=10,
         help='max period which a Track survive without assignments in frames'
     )
@@ -565,18 +555,34 @@ if __name__ == '__main__':
     ### StrongSORT implementation don't use the feature bank but the feature
     ### stored inside Track object and updated using the momentum term
     parser.add_argument(
-        '--feature-momentum', # Old strong_sort.yaml STRONGSORT.EMA_ALPHA
+        '--feature-momentum',  # Old strong_sort.yaml STRONGSORT.EMA_ALPHA
         type=float, default=0.9,
         help='momentum term for Track.feature update'
     )
     
     parser.add_argument(
-        '--final-gate', # Old strong_sort.yaml STRONGSORT.MAX_DIST
+        '--appearance-gate',  # Old strong_sort.yaml STRONGSORT.MAX_DIST
         type=float, default=0.2,
-        help='final track-detection association gate: associations with cost greater than --cost_thres are disregarded'
+        help='track-detection associations with appearance cost greater than this value are disregarded'
     )
 
+    parser.add_argument(
+        '--motion-only-position',
+        action='store_true', 
+        help='use only centroid position to compute motion cost'
+    )
 
+    parser.add_argument(
+        '--motion-gate-coefficient',
+        type=float, default=1.0,
+        help='coefficient that multiplies the motion gate to control track-detection associations'
+    )
+
+    parser.add_argument(
+        '--max-centroid-distance',
+        type=int, default=None,
+        help='max distance in pixels between track and detection centroids for track-detection match'
+    )
 
     opt = parser.parse_args()
     print(opt)


### PR DESCRIPTION
- Fix --draw-trajectory keeping trajectory points from past videos
- Remove cost matrix gating from min_cost_matching() and let only inside Tracker
- Appearance gating based on appearance cost only and not weighted motion-appearance cost matrix
- Remove appearance max distance (appearance gate) from nn_matching
- Detection() object as construction parameter of Track() instead of xyah bbox coordinates
- Save inside Track() objs the last associated detection as Detection() obj
- Tracking results from the last associated detections instead of the bboxes extracted from the state space distribution's mean
- Add only-position flag for motion cost calculation using only KF's centroid information
- Add motion-gate-coefficient flag for controlling motion gate
- Gate track-detection associations by distance between track's last associated detection and new measurements centroids
- Refact/optimize some code portions